### PR TITLE
Update OperaDriver and ChromeDriver info and keep two rows consistent

### DIFF
--- a/src/main/webapp/download/index.jsp
+++ b/src/main/webapp/download/index.jsp
@@ -151,8 +151,8 @@
     <tbody>
       <tr>
         <td><a href="http://code.google.com/p/chromedriver/">Chrome</a></td>
-        <td><a href="http://code.google.com/p/chromedriver/downloads/list">2.3</a>&nbsp;&nbsp;</td>
-        <td><a href="http://chromedriver.googlecode.com/files/release_notes_2.3.txt">release notes</a>&nbsp;&nbsp;</td>
+        <td><a href="http://chromedriver.storage.googleapis.com/index.html">2.4</a>&nbsp;&nbsp;</td>
+        <td><a href="http://chromedriver.storage.googleapis.com/2.4/notes.txt">change log</a>&nbsp;&nbsp;</td>
         <td><a href="http://code.google.com/p/chromedriver/issues/list">issue tracker</a>&nbsp;&nbsp;</td>
         <td><a href="http://code.google.com/p/selenium/wiki/ChromeDriver">selenium wiki page</a>&nbsp;&nbsp;</td>
         <td>Released 2013-09-02</td>


### PR DESCRIPTION
1. Update OperaDriver information in Third Party section.
2. Update ChromeDriver information and keep it consistent with OperaDriver row.
   - Put version number in the second column
   - Add `change log` in the third column (for ChromeDriver, it only has `release notes` for each version)
   - Add the latest release date in the last column
