### PR TITLE
Put short IDE section near the top

### DIFF
--- a/src/main/webapp/download/index.jsp
+++ b/src/main/webapp/download/index.jsp
@@ -40,6 +40,13 @@
   "/download/maven.html">Maven users</a> (Maven is a popular Java build
   tool).</p>
 
+  <h3>Selenium IDE</h3>
+  <p>Selenium IDE is a Firefox plugin which records and plays back user interactions with the browser. Use this to either create simple scripts or assist in exploratory testing. It can also export Remote Control or WebDriver scripts, though they tend to be somewhat brittle and should be overhauled into some sort of Page Object-y structure for any kind of resiliency.</p>
+  <p>Download latest released version <a href="http://release.seleniumhq.org/selenium-ide/2.9.0/selenium-ide-2.9.0.xpi">2.9.0</a> released on 09/Mar/2015 or view the <a href="https://github.com/SeleniumHQ/selenium/wiki/SeIDE-Release-Notes">Release Notes</a> and then <a href="#side_plugins">install some plugins</a>.</p>
+  <p>Download previous version <a href="http://release.seleniumhq.org/selenium-ide/2.8.0/selenium-ide-2.8.0.xpi">2.8.0</a> released on 29/Sep/2014.</p>
+  <!-- <p>Download next unreleased version <a href="http://release.seleniumhq.org/selenium-ide/2.6.0/selenium-ide-2.6.0.xpi">2.6.0</a> to be released on 16/September/2013</p> -->
+  <!-- <p>Download version under development <a href="http://ci.seleniumhq.org:8080/job/IDE/lastSuccessfulBuild/artifact/selenium-trunk/build/ide/selenium-ide-multi.xpi">unreleased</a> (currently disabled)</p> -->
+
   <h3>Selenium Standalone Server</h3>
   <p>The Selenium Server is needed in order to run either Selenium RC style scripts or Remote Selenium WebDriver ones. The 2.x server is a drop-in replacement for the old Selenium RC server and is designed to be backwards compatible with your existing infrastructure.</p>
   <p>Download version <a href="http://goo.gl/PJUZfa">2.48.2</a>
@@ -57,6 +64,11 @@
     bit Windows IE</a> or <a
     href="http://selenium-release.storage.googleapis.com/2.48/IEDriverServer_x64_2.48.0.zip">64 bit Windows IE</a><br/>
     <a href="http://goo.gl/LJ07LL">CHANGELOG</a></p>
+
+  <a name="side_plugins"/>
+  <h3>Selenium IDE Plugins</h3>
+  <p>Selenium IDE can be extended through its own plugin system. Here are a number of plugins that have been created using it. For more information on how to create your own plugin or have it listed, see the <a href="http://seleniumhq.org/projects/ide/plugins.html">plugin tutorial page</a>.</p>
+  <p>Please note that these are not supported by the Selenium project and all issues need to be raised with the relevant developers.</p>
 
   <a name="client-drivers"/>
   <h3>Selenium Client & WebDriver Language Bindings</h3>
@@ -352,18 +364,6 @@
     <p class="description">VisGrid is a GUI for Selenium Grid. You can start hub, create and attach a Selenium node very easily and quickly.</p>
   </div>
 
-  <h3>Selenium IDE</h3>
-  <p>Selenium IDE is a Firefox plugin which records and plays back user interactions with the browser. Use this to either create simple scripts or assist in exploratory testing. It can also export Remote Control or WebDriver scripts, though they tend to be somewhat brittle and should be overhauled into some sort of Page Object-y structure for any kind of resiliency.</p>
-  <p>Download latest released version <a href="http://release.seleniumhq.org/selenium-ide/2.9.0/selenium-ide-2.9.0.xpi">2.9.0</a> released on 09/Mar/2015 or view the <a href="https://github.com/SeleniumHQ/selenium/wiki/SeIDE-Release-Notes">Release Notes</a> and then <a href="#side_plugins">install some plugins</a>.</p>
-  <p>Download previous version <a href="http://release.seleniumhq.org/selenium-ide/2.8.0/selenium-ide-2.8.0.xpi">2.8.0</a> released on 29/Sep/2014.</p>
-  <!-- <p>Download next unreleased version <a href="http://release.seleniumhq.org/selenium-ide/2.6.0/selenium-ide-2.6.0.xpi">2.6.0</a> to be released on 16/September/2013</p> -->
-  <!-- <p>Download version under development <a href="http://ci.seleniumhq.org:8080/job/IDE/lastSuccessfulBuild/artifact/selenium-trunk/build/ide/selenium-ide-multi.xpi">unreleased</a> (currently disabled)</p> -->
-
-  <a name="side_plugins"/>
-  <h3>Selenium IDE Plugins</h3>
-  <p>Selenium IDE can be extended through its own plugin system. Here are a number of plugins that have been created using it. For more information on how to create your own plugin or have it listed, see the <a href="http://seleniumhq.org/projects/ide/plugins.html">plugin tutorial page</a>.</p>
-  <p>Please note that these are not supported by the Selenium project and all issues need to be raised with the relevant developers.</p>
-  
   <h3>Selenium IDE Plugins (that provide new / improved features)</h3>
 
   <div class="plugin">


### PR DESCRIPTION
This is probably a little controversial but here goes:
Every time I see or ask someone to download the seleniumIDE they go to the selenium downloads page, they read through the first couple of screens, they think ah, standalone server must be it and they try installing that.  After a few miss-steps like this some folks give up
My suggestion is to move the 'IDE" section up for better visibility.  However - to be very clear - I am NOT saying 'favor having the ide section first' because after all many people don't want the IDE they want the server.
My point is as follows:  The IDE paragraph and download is very short.  If it was placed first, novices would see it right away AND more advanced users would be more likely to: see it, know it doesn't apply to them, they see the selenium driver download right below it, a few lines down without scrolling.
So I am not saying that there are 'more' IDE users or that the IDE stuff should have priority or anything like that.
I am saying that the IDE part is currently buried and non-obvious which significantly effects novice user and this can addressed by moving the paragraph up and I think that doing so will not significantly impact users looking for the server download which will be visible on the same page without scrolling.