### PR TITLE
Adding the Se Conf events list

### DIFF
--- a/src/main/webapp/about/events.jsp
+++ b/src/main/webapp/about/events.jsp
@@ -17,7 +17,41 @@
 
   <h2>Past events</h2>
   <div id="past-events"><img src="/images/loading.gif" alt="loading events"/></div>
-
+      <table border="1" cellpadding="1" cellspacing="1" id="official-conference" style="width:500px;">
+	<caption>The Annual Selenium Conference</caption>
+	<tbody>
+		<tr>
+			<td>Event</td>
+			<td>Location</td>
+			<td>Videos</td>
+		</tr>
+		<tr>
+			<td>SeConf&#39;11</td>
+			<td>San Francisco, USA</td>
+			<td>&nbsp;</td>
+		</tr>
+		<tr>
+			<td>SeConf&#39;12</td>
+			<td>London, UK</td>
+			<td><a href="https://www.youtube.com/playlist?list=PLCieebVYUBeOdqTjaHtqrtF5Ld7_cVDQl">link</a></td>
+		</tr>
+		<tr>
+			<td>SeConf&#39;13</td>
+			<td>Boston, USA</td>
+			<td><a href="https://www.youtube.com/playlist?list=PLCieebVYUBeP1vNIcXKSQcIGHZwGhYg6p">link</a></td>
+		</tr>
+		<tr>
+			<td>SeConf&#39;14</td>
+			<td>Bangalore, INDIA</td>
+			<td><a href="https://www.youtube.com/watch?v=jjY0eBQFZJI&amp;list=PL9Z-JgiTsOYQjHFwf5maIjFXahl-d0gvU">link</a></td>
+		</tr>
+		<tr>
+			<td>SeConf&#39;15</td>
+			<td>Portland, USA</td>
+			<td><a href="https://www.youtube.com/playlist?list=PLRdSclUtJDYXehIM7SyQyIghLDmE015Gc">link</a></td>
+		</tr>
+	</tbody>
+</table>
   <script src="/js/events.js" type="text/javascript"></script>
 
 <%@include file="/jsp/footer.jspf"%>


### PR DESCRIPTION
Events link from this page http://www.seleniumhq.org/about/ is empty so adding the official SeConf conferences. Being in Workhorse committee will update the latest info here as well for 2016