### PR TITLE
Microsoft Edge Driver link updates.

### DIFF
--- a/src/main/webapp/download/index.jsp
+++ b/src/main/webapp/download/index.jsp
@@ -198,6 +198,13 @@
       </tr>
       <tr>
         <td><a href="https://www.microsoft.com/en-us/download/details.aspx?id=48740">Microsoft Edge Driver</a></td>
+        <td colspan=2><a href="https://www.microsoft.com/en-us/download/details.aspx?id=49962">2.0</a></td>
+        <td><a href="http://connect.microsoft.com/">issue tracker</a></td>
+        <td><a href="http://dev.modern.ie/platform/status/webdriver/details/">Implementation Status</a></td>
+        <td>Released 2016-11-18</td>
+      </tr>
+      <tr>
+        <td><a href="https://www.microsoft.com/en-us/download/details.aspx?id=48740">Microsoft Edge Driver for Windows Insiders</a></td>
         <td colspan=2><a href="https://www.microsoft.com/en-us/download/details.aspx?id=48740">2.1</a></td>
         <td><a href="http://connect.microsoft.com/">issue tracker</a></td>
         <td><a href="http://dev.modern.ie/platform/status/webdriver/details/">Implementation Status</a></td>


### PR DESCRIPTION
The Microsoft Edge Driver link in the current page, points to the Insider builds. This will not work for regular Windows 10 users, who have not signed up for the Microsoft Insider program and who don't have the Windows Insider updates.
Added Microsoft Edge Drive 2.0 link to the page, which will work with the release version of Windows 10.