### PR TITLE
Modification of W3schools Xpath URL

### DIFF
--- a/src/main/rst/02_selenium_ide.rst
+++ b/src/main/rst/02_selenium_ide.rst
@@ -894,7 +894,7 @@ the ``xpath=`` label when specifying an XPath locator.
 These examples cover some basics, but in order to learn more, the 
 following references are recommended:
 
-* `W3Schools XPath Tutorial <http://www.w3schools.com/Xpath/>`_ 
+* `W3Schools XPath Tutorial <http://www.w3schools.com/xsl/xpath_intro.asp>`_ 
 * `W3C XPath Recommendation <http://www.w3.org/TR/xpath>`_
 
 There are also a couple of very useful Firefox Add-ons that can assist in 


### PR DESCRIPTION
The URL mentioned in the document for Xpath tutorial of W3schools is not pointing to the xpath tutorial(Showing page not found error). Modified the URL with the current w3schools xpath tutorial URL.