### PR TITLE
Clarify abbreviated terms introduced

### DIFF
--- a/src/main/rst/06_test_design_considerations.rst
+++ b/src/main/rst/06_test_design_considerations.rst
@@ -395,12 +395,12 @@ to be able to carry out further operations (i.e. login button on home page
 of a portal) then this safe method technique should not be used.
 
 
-UI Mapping
+User Interface Mapping
 ----------
 
-A UI Map is a mechanism that stores all the locators for a test suite in one place
+A User Interface (UI) Map is a mechanism that stores all the locators for a test suite in one place
 for easy modification when identifiers or paths to UI elements change in
-the AUT.  The test script then uses the UI Map for locating
+the application under test (AUT).  The test script then uses the UI Map for locating
 the elements to be tested.  Basically, a UI map is a repository of test script objects
 that correspond to UI elements of the application being tested.  
 

--- a/src/main/rst/06_test_design_considerations.rst
+++ b/src/main/rst/06_test_design_considerations.rst
@@ -396,7 +396,7 @@ of a portal) then this safe method technique should not be used.
 
 
 User Interface Mapping
-----------
+----------------------
 
 A User Interface (UI) Map is a mechanism that stores all the locators for a test suite in one place
 for easy modification when identifiers or paths to UI elements change in


### PR DESCRIPTION
Terms like UI and AUT make it incomprehensible to understand this document if the user is not clear on their definition. I propose defining these terms before they are commonly used.