### PR TITLE
Remove extra word "Selenium" for version for Python

### DIFF
--- a/src/main/webapp/download/index.jsp
+++ b/src/main/webapp/download/index.jsp
@@ -102,7 +102,7 @@
       </tr>
       <tr>
         <td>Python</td>
-        <td>Selenium 3.0.2</td>
+        <td>3.0.2</td>
         <td>2016-11-29</td>
         <td><a href="http://pypi.python.org/pypi/selenium">Download</a></td>
         <td><a href="http://goo.gl/rHRdgk">Change log</a></td>


### PR DESCRIPTION
Remove extra word "Selenium" for version for Python