### PR TITLE
Fix character encoding for the site.

### DIFF
--- a/src/main/rst/.templates/layout.html
+++ b/src/main/rst/.templates/layout.html
@@ -91,6 +91,7 @@
 
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
+    <meta charset="UTF-8" />
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     {{ metatags }}
     {%- if not embedded %}


### PR DESCRIPTION
- Most of the documentation is broken due to wrong character encoding passed