### PR TITLE
Updated tophatpromo.css to hide the promo banner of Seleniumconf chicago ticket sale

### DIFF
--- a/src/main/webapp/tophatpromo.css
+++ b/src/main/webapp/tophatpromo.css
@@ -1,5 +1,5 @@
 #promo {
-  display: none;
+  display: hide; /* hiding SeleniumConf Chicago promo banner from the website, it can be enabled by changing the property to 'none' */
   position: fixed;
   z-index: 101;
   top: 0;


### PR DESCRIPTION
hiding SeleniumConf Chicago promo banner from the website, it can be enabled by changing the property to 'none'

@shs96c  - Simon, Please review the change for hiding the selenium conf sale ticket banner from the webpages. Appreciate if you can let me if this is appropriate  