### PR TITLE
#203 - Corrected Maven Reference Issue

### DIFF
--- a/src/main/rst/03_webdriver.rst
+++ b/src/main/rst/03_webdriver.rst
@@ -90,7 +90,7 @@ your project.
 
 Be sure you specify the most current version.  At the time of writing, the version listed above was
 the most current, however there were frequent releases immediately after the release of Selenium 2.0.
-Check the `Maven download page <http://seleniumhq.org/download/maven.html>`_ for the current release and edit the above dependency accordingly.
+Check the `Maven download page <https://www.seleniumhq.org/download/maven.jsp>`_ for the current release and edit the above dependency accordingly.
 
 Now, from a command-line, CD into the project directory and run maven as follows.
 


### PR DESCRIPTION
Corrected Maven reference under **Java** subsection of '**Setting Up a Selenium-WebDriver Project**' in [https://www.seleniumhq.org/docs/03_webdriver.jsp](https://www.seleniumhq.org/docs/03_webdriver.jsp) page  . Prior to this change , It was referring to old landing page for Maven resource. Now it refers to [maven.jsp documentation](https://www.seleniumhq.org/download/maven.jsp) 

Issue #203 is addressed with this change