### PR TITLE
add redirect for slack

### DIFF
--- a/src/main/webapp/slack/index.html
+++ b/src/main/webapp/slack/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Selenium - Slack Redirect</title>
+    <meta http-equiv="refresh" content="0; URL='https://goo.gl/9o4J3Y'" />
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
The herokuapp we've been using for allowing people to get an invite to our Slack channel is now broken, this will take users directly to the Slack supported means of signing up.

Allow users to navigate to: `https://www.seleniumhq.org/slack` to get to the invite page for Slack.
