### PR TITLE
Add Coveros to List of Commercial Support, Services and Training

### DIFF
--- a/src/main/webapp/ecosystem/index.jsp
+++ b/src/main/webapp/ecosystem/index.jsp
@@ -107,6 +107,10 @@
             <a rel="nofollow" href="https://testsmith.io">Testsmith</a> - 
             Dutch company providing Selenium WebDriver consultancy, training and workshops.
         </li>
+        <li>
+            <a rel="nofollow" href="https://www.coveros.com">Coveros</a> - 
+            Selenium test automation, custom Selenium frameworks, Selenium test integration into CI/CD and DevOps pipeline, and Selenium training.
+        </li>
     </ul>
 
     <h2>Commercial Training</h2>


### PR DESCRIPTION
Adding Coveros to list of Commerical Support, Services and Training. Coveros has been providing consulting services to the software development field for over a decade, focusing on agile practices, specifically continuous testing and DevSecOps. Coveros has engineers who have been working with Selenium since 2005, and has several training courses focused on learning Selenium